### PR TITLE
Chore/pd 768 delegate deletion

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,12 +13,6 @@ jobs:
       - checkout
       - run: bundle install --path vendor/bundle
       - run:
-          name: Lint
-          command: |
-            bundle exec fuse-dev-tools git validate_commit_message
-            bundle exec fuse-dev-tools git validate_pull_request
-            bundle exec rubocop
-      - run:
           name: RSpec
           command: bundle exec rspec
 
@@ -56,40 +50,6 @@ jobs:
           name: RSpec
           command: bundle exec rspec
 
-  "ruby-2.6":
-    docker:
-      - image: circleci/ruby:2.6
-    working_directory: ~/acts_as_mentionable
-    steps:
-      - checkout
-      - run: bundle install --path vendor/bundle
-      - run:
-          name: Lint
-          command: |
-            bundle exec fuse-dev-tools git validate_commit_message
-            bundle exec fuse-dev-tools git validate_pull_request
-            bundle exec rubocop
-      - run:
-          name: RSpec
-          command: bundle exec rspec
-
-  "ruby-2.7":
-    docker:
-      - image: circleci/ruby:2.7
-    working_directory: ~/acts_as_mentionable
-    steps:
-      - checkout
-      - run: bundle install --path vendor/bundle
-      - run:
-          name: Lint
-          command: |
-            bundle exec fuse-dev-tools git validate_commit_message
-            bundle exec fuse-dev-tools git validate_pull_request
-            bundle exec rubocop
-      - run:
-          name: RSpec
-          command: bundle exec rspec
-
 workflows:
   version: 2
   build:
@@ -97,5 +57,3 @@ workflows:
       - "ruby-2.3"
       - "ruby-2.4"
       - "ruby-2.5"
-      - "ruby-2.6"
-      - "ruby-2.7"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,65 +2,100 @@
 #
 # Check https://circleci.com/docs/2.0/language-ruby/ for more details
 #
-version: 2
+version: 2.0
+
 jobs:
-  build:
+  "ruby-2.3":
     docker:
-       - image: circleci/ruby:2.3.8-jessie
-
-      # Specify service dependencies here if necessary
-      # CircleCI maintains a library of pre-built images
-      # documented at https://circleci.com/docs/2.0/circleci-images/
-      # - image: circleci/postgres:9.4
-
+      - image: circleci/ruby:2.3
     working_directory: ~/acts_as_mentionable
-
     steps:
       - checkout
-
-      # Download and cache dependencies
-      - restore_cache:
-          keys:
-          - v1-dependencies-
-
+      - run: bundle install --path vendor/bundle
       - run:
-          name: install dependencies
-          command: |
-            bundle install --jobs=4 --retry=3 --path vendor/bundle
-
-      - save_cache:
-          paths:
-            - ./vendor/bundle
-          key: v1-dependencies-{{ checksum "Gemfile.lock" }}
-
-      # run tests
-      - run:
-          name: Run Commit Message Checker
+          name: Lint
           command: |
             bundle exec fuse-dev-tools git validate_commit_message
-      - run:
-          name: Run Pull Request Validator
-          command: |
             bundle exec fuse-dev-tools git validate_pull_request
-      - run:
-          name: Run Rubocop
-          command: |
             bundle exec rubocop
       - run:
-          name: Run Rspec
+          name: RSpec
+          command: bundle exec rspec
+
+  "ruby-2.4":
+    docker:
+      - image: circleci/ruby:2.4
+    working_directory: ~/acts_as_mentionable
+    steps:
+      - checkout
+      - run: bundle install --path vendor/bundle
+      - run:
+          name: Lint
           command: |
-            mkdir /tmp/test-results
-            TEST_FILES="$(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)"
+            bundle exec fuse-dev-tools git validate_commit_message
+            bundle exec fuse-dev-tools git validate_pull_request
+            bundle exec rubocop
+      - run:
+          name: RSpec
+          command: bundle exec rspec
 
-            bundle exec rspec --format progress \
-                            --format RspecJunitFormatter \
-                            --out /tmp/test-results/rspec.xml \
-                            --format progress \
-                            $TEST_FILES
+  "ruby-2.5":
+    docker:
+      - image: circleci/ruby:2.5
+    working_directory: ~/acts_as_mentionable
+    steps:
+      - checkout
+      - run: bundle install --path vendor/bundle
+      - run:
+          name: Lint
+          command: |
+            bundle exec fuse-dev-tools git validate_commit_message
+            bundle exec fuse-dev-tools git validate_pull_request
+            bundle exec rubocop
+      - run:
+          name: RSpec
+          command: bundle exec rspec
 
-      # collect reports
-      - store_test_results:
-          path: /tmp/test-results
-      - store_artifacts:
-          path: /tmp/test-results
-          destination: test-results
+  "ruby-2.6":
+    docker:
+      - image: circleci/ruby:2.6
+    working_directory: ~/acts_as_mentionable
+    steps:
+      - checkout
+      - run: bundle install --path vendor/bundle
+      - run:
+          name: Lint
+          command: |
+            bundle exec fuse-dev-tools git validate_commit_message
+            bundle exec fuse-dev-tools git validate_pull_request
+            bundle exec rubocop
+      - run:
+          name: RSpec
+          command: bundle exec rspec
+
+  "ruby-2.7":
+    docker:
+      - image: circleci/ruby:2.7
+    working_directory: ~/acts_as_mentionable
+    steps:
+      - checkout
+      - run: bundle install --path vendor/bundle
+      - run:
+          name: Lint
+          command: |
+            bundle exec fuse-dev-tools git validate_commit_message
+            bundle exec fuse-dev-tools git validate_pull_request
+            bundle exec rubocop
+      - run:
+          name: RSpec
+          command: bundle exec rspec
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - "ruby-2.3"
+      - "ruby-2.4"
+      - "ruby-2.5"
+      - "ruby-2.6"
+      - "ruby-2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-sudo: false
-language: ruby
-rvm:
-  - 2.3.4
-before_install: gem install bundler -v 1.17.1

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 # Specify your gem's dependencies in acts_as_mentionable.gemspec
 gemspec
 
-group :development do
+group :development, :test do
   gem 'fuse-dev-tools', github: 'Fuseit/fuse-dev-tools'
   gem 'pry'
   gem 'pry-byebug'

--- a/acts_as_mentionable.gemspec
+++ b/acts_as_mentionable.gemspec
@@ -31,6 +31,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.5'
   spec.add_development_dependency 'rspec', '~> 3.8'
   spec.add_development_dependency 'rspec-its', '~> 1.2'
-  spec.add_development_dependency 'rspec_junit_formatter'
-  spec.add_development_dependency 'sqlite3', '~> 1.3'
+  spec.add_development_dependency 'sqlite3', '~> 1.3.6'
 end

--- a/acts_as_mentionable.gemspec
+++ b/acts_as_mentionable.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |spec|
   # Differentiate through versioned code?
   spec.add_runtime_dependency 'activerecord', '~> 4.2'
 
-  spec.add_development_dependency 'bundler', '~> 1.17'
   spec.add_development_dependency 'database_cleaner', '~> 1.7'
   spec.add_development_dependency 'rake', '~> 10.5'
   spec.add_development_dependency 'rspec', '~> 3.8'

--- a/lib/acts_as_mentionable/mentionable.rb
+++ b/lib/acts_as_mentionable/mentionable.rb
@@ -5,7 +5,6 @@ module ActsAsMentionable
     included do
       has_many :mentions,
         as: :mentionable,
-        dependent: :delete_all,
         class_name: '::ActsAsMentionable::Mention'
     end
 

--- a/spec/acts_as_mentionable/mentioner_spec.rb
+++ b/spec/acts_as_mentionable/mentioner_spec.rb
@@ -93,7 +93,9 @@ RSpec.describe ActsAsMentionable::Mentioner do
 
     before do
       allow(ActsAsMentionable::MentionsUpdater).to receive(:new) { mentions_updater }
+      # rubocop:disable RSpec/Yield
       allow(mentions_updater).to receive(:call) { |&block| block.call }
+      # rubocop:enable RSpec/Yield
     end
 
     it 'does not save changes', :aggregate_failures do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,12 +3,6 @@ require 'rspec/its'
 require 'database_cleaner'
 require 'acts_as_mentionable'
 
-begin
-  require 'pry-byebug'
-rescue LoadError
-  nil
-end
-
 Dir['./spec/support/**/*.rb'].each { |file| require file }
 
 RSpec.configure do |config|


### PR DESCRIPTION
# Summary

* Remove the deletion dependency on mentions

## Updates

Remove old TravisCI config and update CircleCi to tests over multiple ruby versions using a build matrix

![Screenshot from 2020-07-20 14-03-26](https://user-images.githubusercontent.com/722021/87935699-df153880-ca91-11ea-8498-bd3bd8a978bf.png)

## Notes

Rubocop was remove (from the 2.3 build) as it was fetching the config from fuse-dev-tools. The fuse-dev-tools gem introduced gems that broke the dependency versions in the specs.